### PR TITLE
Make run.sh run on Windows

### DIFF
--- a/scripts/run.sh
+++ b/scripts/run.sh
@@ -1,3 +1,9 @@
 #!/bin/sh
 
-./build/trading-platform-pp
+# Windows
+if [[ ("$OSTYPE" == "cygwin") ||  ("$OSTYPE" == "msys")]]; then 
+    ./build/release/trading-platform-pp
+# Linux
+else
+    ./build/trading-platform-pp 
+fi


### PR DESCRIPTION
Current run.sh file only supports Linux. I added a few lines so it can be run on both Linux and Windows.