### PR TITLE
Asynchronous process for news

### DIFF
--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -88,6 +88,7 @@ void MainWindow::on_actionNews_triggered() {
   hideAllPages();
   uncheckAllTabs();
   ui->actionNews->setChecked(true);
+  newsPage->update();
   newsPage->show();
 }
 

--- a/src/gui/newspage.cpp
+++ b/src/gui/newspage.cpp
@@ -3,6 +3,7 @@
 
 #include <QDebug>
 #include <QJsonObject>
+#include <QDateTime>
 #include "newscard.h"
 #include "helper/helper.h"
 
@@ -14,15 +15,25 @@ NewsPage::NewsPage(QWidget *parent) :
   ui(new Ui::NewsPage) {
   ui->setupUi(this);
 
+  latestTimestamp = -1e9;
   news = new News();
   layout = new QVBoxLayout(ui->scrollArea);
 
   QWidget *widget = new QWidget();
   widget->setLayout(layout);
   ui->scrollArea->setWidget(widget);
+}
+
+void NewsPage::update() {
+  long now = QDateTime::currentDateTime().toTime_t();
+
+  if (now - latestTimestamp < 60 * 5) { // 5 minutes
+    return;
+  }
+
+  latestTimestamp = now;
 
   news->updateMarketNews();
-
   auto newsArray = news->getMarketNews();
 
   int count = 0;
@@ -39,6 +50,7 @@ NewsPage::NewsPage(QWidget *parent) :
       QString(readableTime.c_str()),
       json["url"].toString(),
       this);
+
     layout->addWidget(newsCard);
 //    newsCard->debug();
   }

--- a/src/gui/newspage.h
+++ b/src/gui/newspage.h
@@ -15,8 +15,10 @@ class NewsPage : public QWidget {
  public:
   explicit NewsPage(QWidget *parent = nullptr);
   ~NewsPage();
+  void update();
 
  private:
+  long latestTimestamp;
   Ui::NewsPage *ui;
   News *news;
   QVBoxLayout *layout;


### PR DESCRIPTION
Only call the API when the News tab is triggered. Also, never update news when the latest update is less than 5 minutes apart.